### PR TITLE
Added GET /api/agent/listings with params "limit" and "offset"

### DIFF
--- a/src/app/api/agent/listings/route.ts
+++ b/src/app/api/agent/listings/route.ts
@@ -4,6 +4,51 @@ import { ListingService } from "@/domain/listings/service"
 import { createListingSchema, validateAddressFormat } from "@/domain/listings/validation"
 import { ZodError } from "zod"
 
+export const { GET } = createApiHandler({
+  GET: async (req) => {
+	try {
+	  // Authenticate agent
+	  const authHeader = req.headers.get("Authorization")
+	  const apiKey = extractBearerToken(authHeader)
+
+	  if (!apiKey) {
+		return errorResponse("Missing or invalid Authorization header", 401)
+	  }
+
+	  const auth = await verifyApiKey(apiKey)
+	  if (!auth) {
+		return errorResponse("Invalid API key", 401)
+	  }
+
+	  // Parse query parameters
+	  const searchParams = req.nextUrl.searchParams
+	  const limit = searchParams.get("limit")
+		? parseInt(searchParams.get("limit")!)
+		: 20
+	  const offset = searchParams.get("offset")
+		? parseInt(searchParams.get("offset")!)
+		: 0
+
+	  // Search listings
+	  const { items, nextCursor, hasMore } = await ListingService.search({
+		limit,
+		offset,
+	  })
+
+	  return successResponse({
+		listings: items,
+		total: items.length,
+	  })
+	} catch (error: unknown) {
+	  console.error("Agent search error:", error)
+	  return errorResponse(
+		error instanceof Error ? error.message : "Failed to search listings",
+		500
+	  )
+	}
+  },
+})
+
 export const { POST } = createApiHandler({
   POST: async (req) => {
     try {

--- a/src/domain/listings/service.ts
+++ b/src/domain/listings/service.ts
@@ -248,6 +248,8 @@ export class ListingService {
 
     const limit = params.limit || 20
 
+	const offset = params.offset || 0
+
     const listings = await db.listing.findMany({
       where,
       include: {
@@ -267,7 +269,7 @@ export class ListingService {
         cursor: {
           id: params.cursor,
         },
-        skip: 1, // Skip the cursor itself
+        skip: 1 + offset, // Skip the cursor itself
       }),
     })
 


### PR DESCRIPTION
## Type of change:
Feature update: Added handling for GET requests on /api/agent/listings.

## Files changed:
**src/app/api/agent/listings/route.ts** - Added exported GET API handler that fetches the listings with 2 accepted params: "offset" with a default value of 0, and "limit" with a default value of 20.
Returns { listings, total }

**src/domain/listings/service.ts** - ListingService.search now supports "offset" parameter, added it to the skip argument in the Prisma search, so that the skip is now (1 + offset).

Closes #11 

*Note: The offset was treated as the number of records to be skipped, not a page number, multiply by limit to treat as page number.*